### PR TITLE
ENG-12694 new check: only macro syntax for Ecto

### DIFF
--- a/lib/checks/ecto_only_macro_syntax.ex
+++ b/lib/checks/ecto_only_macro_syntax.ex
@@ -1,0 +1,47 @@
+defmodule TallariumCredo.Checks.EctoOnlyMacroSyntax do
+  @moduledoc """
+  Permit only the use of the macro syntax from the Ecto.Query module
+  """
+
+  use Credo.Check, base_priority: :high, category: :warning
+
+  import Destructure
+
+  @doc false
+  @impl true
+  def run(source_file, params \\ []) do
+    issue_meta = IssueMeta.for(source_file, params)
+
+    initial_state = d(%{issue_meta, has_ecto_query_import?: false, issues: []})
+
+    d(%{issues}) = Credo.Code.prewalk(source_file, &traverse/2, initial_state)
+    issues
+  end
+
+  defp traverse(
+         {:import, _meta, [{:__aliases__, _aliases_meta, [:Ecto, :Query]}]} = ast,
+         state
+       ) do
+    {ast, %{state | has_ecto_query_import?: true}}
+  end
+
+  defp traverse(
+         {:from, meta, [{:in, _meta, _children} | _]} = ast,
+         d(%{has_ecto_query_import?}) = state
+       )
+       when has_ecto_query_import? do
+    issues = state.issues ++ [issue_for(state.issue_meta, meta[:line])]
+    {ast, %{state | issues: issues}}
+  end
+
+  defp traverse(ast, state) do
+    {ast, state}
+  end
+
+  defp issue_for(issue_meta, line_no) do
+    format_issue(issue_meta,
+      message: "Only the macro syntax from Ecto.Query is permitted",
+      line_no: line_no
+    )
+  end
+end

--- a/test/checks/ecto_only_macro_syntax_test.exs
+++ b/test/checks/ecto_only_macro_syntax_test.exs
@@ -1,0 +1,37 @@
+defmodule TallariumCredo.Checks.EctoOnlyMacroSyntaxTest do
+  use Credo.Test.Case
+
+  alias TallariumCredo.Checks.EctoOnlyMacroSyntax
+
+  test "disallows the keyword syntax from Ecto.Query" do
+    """
+    defmodule MyModule do
+      import Ecto.Query
+
+      def query do
+        from u in User, where: u.name == "John"
+      end
+    end
+    """
+    |> to_source_file()
+    |> run_check(EctoOnlyMacroSyntax)
+    |> assert_issue()
+  end
+
+  test "ignores from statements without the Ecto.Query import" do
+    """
+    defmodule MyModule do
+      def query do
+        from u in User, where: u.name == "John"
+      end
+
+      defp from(_source, _queryable) do
+        :ok
+      end
+    end
+    """
+    |> to_source_file()
+    |> run_check(EctoOnlyMacroSyntax)
+    |> refute_issues()
+  end
+end


### PR DESCRIPTION
https://tallarium.atlassian.net/browse/ENG-12694

Adhering to one (pipeline-based) syntax will make the critical and complex Ecto code easier to scan - `from X in T` is an expression that only appears in the other syntax (which Ecto calls "keyword syntax")